### PR TITLE
Fix links for WSO2 and Kong AI Gateway setup in README

### DIFF
--- a/asgardeo-agent-identity-with-ai-gateway/README.md
+++ b/asgardeo-agent-identity-with-ai-gateway/README.md
@@ -45,8 +45,8 @@ Before you begin, ensure you have the following:
 
 Choose your preferred AI Gateway and follow the corresponding setup guide:
 
-- **WSO2 AI Gateway[Link neeeds to be added]** — Configure WSO2 with Asgardeo for agent authentication
-- **Kong AI Gateway[Link neeeds to be added]** — Configure Kong with Asgardeo for agent authentication
+- **[WSO2 AI Gateway](https://wso2.com/asgardeo/docs/tutorials/wso2-ai-gateway-with-agent-identity-aware-access-control)** — Configure WSO2 with Asgardeo for agent authentication
+- **[Kong AI Gateway](https://wso2.com/asgardeo/docs/tutorials/kong-ai-gateway-with-agent-identity-aware-access-control)** — Configure Kong with Asgardeo for agent authentication
 
 ---
 


### PR DESCRIPTION
This pull request updates the `README.md` to provide direct links to setup guides for WSO2 and Kong AI Gateways, making it easier for users to access the relevant documentation.

Documentation improvements:

* Added official links for WSO2 and Kong AI Gateway setup guides in the  `README.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI Gateway setup guide documentation links with fully qualified references to agent identity aware access control tutorials for both WSO2 and Kong configurations, replacing placeholder URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->