### PR TITLE
Add CIBA-based OBO flow sample and Tasks MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ This repo includes the samples that demonstrate securing AI applications using t
 4) [MCP Auth/Python](mcp-auth/python/README.md) - Example implementation of a protected Python MCP server secured with the WSO2 IAM platform
 5) [MCP Auth/TypeScript](mcp-auth/typescript/README.md) - Example implementation of a protected TypeScript MCP server secured with the WSO2 IAM platform
 6) [Agent Identity/Python](agent-identity/python/README.md) - Demonstrates how AI agents authenticate with Asgardeo using either direct Agent Credentials or user-delegated OBO tokens. These samples show how agents securely obtain and use access tokens to call backend services or MCP tool servers.
+7) [Agent Identity/Python — CIBA OBO Flow](agent-identity/python/ciba-on-behalf-of-flow/README.md) - AI agent uses CIBA to request user consent out-of-band (email) and step up to an OBO token with higher scopes, without a browser redirect.
+8) [MCP Auth/Python Tasks Server](mcp-auth/python-tasks/README.md) - A secured MCP server with per-tool scope enforcement, designed to demonstrate the CIBA-based OBO step-up flow.

--- a/agent-identity/python/README.md
+++ b/agent-identity/python/README.md
@@ -1,6 +1,6 @@
 # Agent Identity Quickstart — Python Samples
 
-This directory contains four Python-based sample implementations demonstrating how to authenticate AI agents with Asgardeo and securely interact with MCP servers. Each scenario showcases a different authentication model.
+This directory contains Python-based sample implementations demonstrating how to authenticate AI agents with Asgardeo and securely interact with MCP servers. Each scenario showcases a different authentication model.
 
 ## Available Scenarios
 
@@ -14,5 +14,11 @@ This directory contains four Python-based sample implementations demonstrating h
 
 - AI agent authenticates **on behalf of a user** using _Authorization Code + PKCE_.
 - The user signs in through Asgardeo, and the agent exchanges the authorization code for an **OBO token** representing the user.
+
+### ciba-on-behalf-of-flow/
+
+- AI agent authenticates **on behalf of a user** using the **CIBA grant** — no browser redirect required.
+- The agent detects an `insufficient_scope` error from the MCP server, prompts for the user's email, and initiates a CIBA request. The user approves via email on any device, and the agent receives an OBO token with elevated scopes.
+- Ideal for CLI-only environments, back-office agents, and server-side workers.
 
 Each directory includes its own README with setup instructions, environment variable configuration, and runnable examples using modern agent development frameworks.

--- a/agent-identity/python/ciba-on-behalf-of-flow/.env.example
+++ b/agent-identity/python/ciba-on-behalf-of-flow/.env.example
@@ -1,0 +1,32 @@
+# ---------------------------------------
+# Asgardeo OAuth2 Configuration
+# ---------------------------------------
+ASGARDEO_BASE_URL=https://api.asgardeo.io/t/<your-tenant>
+CLIENT_ID=<your-client-id>
+CLIENT_SECRET=<your-client-secret>
+REDIRECT_URI=http://localhost:6274/oauth/callback
+
+# ---------------------------------------
+# Asgardeo Agent Credentials
+# ---------------------------------------
+AGENT_ID=<your-agent-id>
+AGENT_SECRET=<your-agent-secret>
+
+# ---------------------------------------
+# Google Gemini API Key
+# ---------------------------------------
+GOOGLE_API_KEY=<google-api-key>
+
+# LLM model used by the agent (any supported model can be used).
+MODEL_NAME=gemini-2.5-flash
+
+# ---------------------------------------
+# MCP Server
+# ---------------------------------------
+TASKS_MCP_SERVER_URL=http://127.0.0.1:8100/mcp
+
+# ---------------------------------------
+# CIBA Configuration
+# ---------------------------------------
+# Notification channel used to reach the user: email | sms | external
+CIBA_NOTIFICATION_CHANNEL=email

--- a/agent-identity/python/ciba-on-behalf-of-flow/README.md
+++ b/agent-identity/python/ciba-on-behalf-of-flow/README.md
@@ -1,0 +1,227 @@
+# Agent Identity Quickstart - CIBA-based On-Behalf-Of (OBO) Flow
+
+This guide explains how to run the `CIBA-based On-Behalf-Of (OBO) authentication flow` using Asgardeo with the **LangChain** framework.
+
+In this scenario, the AI agent **steps up** from its own agent credentials to a **user-delegated OBO token** using the **CIBA (Client-Initiated Backchannel Authentication)** grant — without requiring a browser redirect on the agent's host. Instead, the user receives an **email notification** and approves the request on any device they choose.
+
+This is ideal for:
+- Back-office agents and CLI-only environments
+- Server-side workers with no browser access
+- Scenarios where the user authenticates on a different device
+
+This example corresponds to the _"AI agent acting on behalf of a user"_ scenario described in the [Agent Authentication Guide](https://wso2.com/asgardeo/docs/guides/agentic-ai/ai-agents/agent-authentication/).
+
+## Prerequisites
+
+- Python 3.10 or higher
+- An Asgardeo account and application setup
+- pip (Python package installer)
+- The Tasks MCP server from this repo (see [mcp-auth/python-tasks/](../../../mcp-auth/python-tasks/))
+
+## Directory Overview
+
+```
+agent-identity/python/ciba-on-behalf-of-flow/
+├── .env.example            # Environment variables template
+├── README.md               # You are here
+└── langchain/              # CIBA OBO flow using LangChain
+    ├── main.py
+    └── requirements.txt
+```
+
+No `common/` directory is needed — CIBA requires no local callback server.
+
+## Register an AI Agent in Asgardeo
+
+1. Sign in to `Asgardeo Console → Agents`
+2. Click `+ New Agent`
+3. Provide:
+   - Name (required)
+   - Description (optional)
+4. Click `Create`
+
+You will receive:
+- Agent ID
+- Agent Secret (shown once) → store securely
+
+You will need these values for the `.env` file.
+
+## Configure an MCP Client Application with CIBA Enabled
+
+CIBA requires a **confidential client** with a `client_secret`. To configure:
+
+1. Go to `Applications → New Application`
+2. Select `MCP Client Application` (or `Standard-Based Application` if CIBA is not available in the MCP template)
+3. Provide:
+   - Application name
+   - Authorized Redirect URL: `http://localhost:6274/oauth/callback`
+4. Finish the wizard
+
+### Enable the CIBA grant
+
+1. Go to the application's **Protocol** tab
+2. Under **Allowed grant types**, enable:
+   - `Client Credentials` (agent flow)
+   - `Token Exchange` (OBO)
+   - **`CIBA`**
+3. Ensure a **Client Secret** is generated (confidential client) — copy it for your `.env` file
+
+### Configure CIBA notification channel
+
+1. In the application settings, navigate to the **CIBA** configuration
+2. Enable the **Email** notification channel
+3. The default expiry time (120 seconds) is suitable for testing
+
+> **Note:** If the MCP Client Application template does not expose the CIBA grant toggle, create a **Standard-Based Application** instead. The scope configuration remains the same.
+
+Make note of:
+- **Client ID** (in the _Protocol_ tab)
+- **Client Secret** (in the _Protocol_ tab)
+- **Tenant name** (visible in the Asgardeo URL)
+
+## Register the API Resource and Scopes
+
+1. Go to `API Resources → + New API Resource`
+2. Create an API resource (e.g., `tasks-api`)
+3. Add the following scopes:
+
+   | Scope | Description |
+   |---|---|
+   | `tasks:templates_read` | Read task templates |
+   | `tasks:read` | Read user's personal tasks |
+   | `tasks:write` | Create tasks for the user |
+
+4. Go back to your MCP Client Application → **API Authorization** tab
+5. Authorize the application for the `tasks-api` scopes
+
+## Set Up the Project Locally
+
+```bash
+cd agent-identity/python/ciba-on-behalf-of-flow/langchain
+```
+
+### Create and activate a virtual environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configure Environment Variables
+
+Copy the `.env.example` in this directory to `.env` and replace the placeholders with your actual values:
+
+```bash
+cp .env.example .env
+```
+
+- `<your-tenant>` → Your tenant ID (visible in the Asgardeo console URL)
+- `<your-client-id>` → from the MCP application
+- `<your-client-secret>` → **Required for CIBA** — from the MCP application's Protocol tab
+- `<your-agent-id>` / `<your-agent-secret>` → Values from your AI agent registration
+- `<google-api-key>` → You can generate one from [Google AI Studio](https://aistudio.google.com/app/api-keys)
+
+The CIBA-specific variables in `.env.example`:
+
+```bash
+CLIENT_SECRET=<your-client-secret>                    # Required for CIBA
+TASKS_MCP_SERVER_URL=http://127.0.0.1:8100/mcp        # Tasks server
+CIBA_NOTIFICATION_CHANNEL=email                       # email | sms | external
+```
+
+### User Pre-requisite
+
+The end-user whose approval is requested must have a **verified email** on their Asgardeo profile. You can onboard a test user by following the [Onboard a User guide](https://wso2.com/asgardeo/docs/guides/users/manage-users/#onboard-single-user).
+
+## Understanding the CIBA OBO Flow
+
+Here's what happens when you run this sample:
+
+1. The agent authenticates with its own Agent Credentials and obtains an **agent token**
+2. The agent connects to the Tasks MCP server using the agent token
+3. The agent successfully calls `list_task_templates` (low-scope tool — agent token is sufficient)
+4. The agent attempts to call `list_my_tasks` → MCP server rejects with `insufficient_scope`
+5. The agent prompts for the user's Asgardeo username (email)
+6. The agent initiates a **CIBA request** with:
+   - `login_hint` = the user's email
+   - `actor_token` = the agent's token
+   - `scopes` = `["openid", "tasks:templates_read", "tasks:read", "tasks:write"]`
+   - `notification_channel` = `email`
+7. Asgardeo sends an **email** to the user with an approval link
+8. The user clicks the approval link on any device
+9. The agent polls the token endpoint and receives an **OBO token** (`act.sub` = agent, `sub` = user)
+10. The agent rebuilds the MCP client with the OBO token and retries — `list_my_tasks` now succeeds
+11. Subsequent requests (e.g., `create_my_task`) use the cached OBO token without re-triggering CIBA
+
+## Running the Flow
+
+You need **two terminals**:
+
+### Terminal A — Start the Tasks MCP Server
+
+```bash
+cd mcp-auth/python-tasks
+python main.py
+```
+
+The server starts on `http://localhost:8100/mcp`.
+
+### Terminal B — Run the Agent
+
+```bash
+cd agent-identity/python/ciba-on-behalf-of-flow/langchain
+python main.py
+```
+
+## Example Transcript
+
+```
+##  This is a CIBA-based On-Behalf-Of (OBO) authentication sample...
+
+Agent token obtained successfully.
+
+Enter your question or type 'exit' to quit: list task templates
+Agent Response: Here are the available task templates:
+1. Weekly Report - Prepare and submit the weekly status report
+2. Code Review - Review pending pull requests and provide feedback
+...
+
+Enter your question or type 'exit' to quit: show my tasks
+
+The agent needs higher privileges to complete this request.
+Enter your Asgardeo username (email): alice@example.com
+
+Approval request sent via email. Waiting up to 120s for approval...
+OBO token obtained successfully. Retrying your request...
+
+Agent Response: You have no tasks yet.
+
+Enter your question or type 'exit' to quit: add a task called buy milk
+Agent Response: Task "buy milk" has been created successfully.
+
+Enter your question or type 'exit' to quit: show my tasks
+Agent Response: Here are your tasks:
+1. buy milk (pending)
+
+Enter your question or type 'exit' to quit: exit
+Exiting the program. Goodbye!
+```
+
+> **Note:** After the first CIBA step-up, subsequent requests use the cached OBO token — no re-approval is needed until the token expires.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Email not received | User's email not verified in Asgardeo | Verify the user's email in `Users → <user> → Profile` |
+| `access_denied` error | User rejected the approval request | Try again — the user must click "Allow" in the email |
+| `expired_token` / timeout | User did not respond within the expiry window (default 120s) | Try again and approve promptly |
+| `slow_down` during polling | Polling too fast | Handled automatically by the SDK — no action needed |
+| `Client secret is required` | `CLIENT_SECRET` not set in `.env` | CIBA requires a confidential client — add `CLIENT_SECRET` to your `.env` file. See [Configure CIBA grant](https://wso2.com/asgardeo/docs/guides/authentication/configure-ciba-grant/) |
+| `insufficient_scope` after step-up | OBO token doesn't include the required scopes | Check API resource authorization in your Asgardeo application |

--- a/agent-identity/python/ciba-on-behalf-of-flow/langchain/main.py
+++ b/agent-identity/python/ciba-on-behalf-of-flow/langchain/main.py
@@ -1,0 +1,156 @@
+"""
+ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+
+  This software is the property of WSO2 LLC. and its suppliers, if any.
+  Dissemination of any information or reproduction of any material contained
+  herein is strictly forbidden, unless permitted by WSO2 in accordance with
+  the WSO2 Commercial License available at http://wso2.com/licenses.
+  For specific language governing the permissions and limitations under
+  this license, please see the license as well as any agreement you've
+  entered into with WSO2 governing the purchase of this software and any
+"""
+
+import os
+import asyncio
+import time
+
+from dotenv import load_dotenv
+from pathlib import Path
+
+from asgardeo import AsgardeoConfig
+from asgardeo_ai import AgentConfig, AgentAuthManager
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain.agents import create_agent
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+load_dotenv(ROOT_DIR / ".env")
+
+ASGARDEO_CONFIG = AsgardeoConfig(
+    base_url=os.getenv("ASGARDEO_BASE_URL"),
+    client_id=os.getenv("CLIENT_ID"),
+    client_secret=os.getenv("CLIENT_SECRET"),
+    redirect_uri=os.getenv("REDIRECT_URI"),
+)
+
+AGENT_CONFIG = AgentConfig(
+    agent_id=os.getenv("AGENT_ID"),
+    agent_secret=os.getenv("AGENT_SECRET"),
+)
+
+TASKS_MCP_SERVER_URL = os.getenv("TASKS_MCP_SERVER_URL", "http://127.0.0.1:8100/mcp")
+CIBA_NOTIFICATION_CHANNEL = os.getenv("CIBA_NOTIFICATION_CHANNEL", "email")
+
+INSUFFICIENT_SCOPE_SENTINEL = "insufficient_scope"
+
+
+def build_mcp_config(access_token: str) -> dict:
+    return {
+        "tasks_server": {
+            "transport": "streamable_http",
+            "url": TASKS_MCP_SERVER_URL,
+            "headers": {
+                "Authorization": f"Bearer {access_token}",
+            },
+        }
+    }
+
+
+def has_insufficient_scope(response: dict) -> bool:
+    """Check if the agent response contains an insufficient_scope error."""
+    for msg in response.get("messages", []):
+        content = msg.content if hasattr(msg, "content") else str(msg)
+        if INSUFFICIENT_SCOPE_SENTINEL in content:
+            return True
+    return False
+
+
+async def main():
+    print("##########################################################################################################")
+    print("##   This is a CIBA-based On-Behalf-Of (OBO) authentication sample for authenticating AI agents        ##")
+    print("##                         using Asgardeo and LangChain framework                                      ##")
+    print("##########################################################################################################")
+
+    async with AgentAuthManager(ASGARDEO_CONFIG, AGENT_CONFIG) as auth_manager:
+        agent_token = await auth_manager.get_agent_token(["openid", "tasks:templates_read"])
+
+        print("\nAgent token obtained successfully.")
+
+        client = MultiServerMCPClient(build_mcp_config(agent_token.access_token))
+
+        llm = ChatGoogleGenerativeAI(
+            model=os.getenv("MODEL_NAME", "gemini-2.5-flash"),
+            temperature=0.9,
+        )
+
+        tools = await client.get_tools()
+        agent = create_agent(llm, tools)
+
+        obo_token = None
+        obo_expires_at = 0
+
+        while True:
+            user_input = input("\nEnter your question or type 'exit' to quit: ")
+            if user_input.lower() == "exit":
+                print("Exiting the program. Goodbye!")
+                break
+
+            response = await agent.ainvoke(
+                {"messages": [{"role": "user", "content": user_input}]}
+            )
+
+            if has_insufficient_scope(response):
+                # Check if we already have a valid OBO token
+                if obo_token and time.time() < obo_expires_at:
+                    print("OBO token is still valid but scopes are insufficient. Cannot retry.")
+                    print("Agent Response:", response["messages"][-1].content)
+                    continue
+
+                print("\nThe agent needs higher privileges to complete this request.")
+                username = input("Enter your Asgardeo username (email): ")
+
+                try:
+                    _, obo_token = await auth_manager.get_obo_token_with_ciba(
+                        login_hint=username,
+                        agent_token=agent_token,
+                        scopes=["openid", "tasks:templates_read", "tasks:read", "tasks:write"],
+                        binding_message=f"AI agent requests access to your tasks: {user_input!r}",
+                        notification_channel=CIBA_NOTIFICATION_CHANNEL,
+                        on_initiated=lambda r: print(
+                            f"\nApproval request sent via {CIBA_NOTIFICATION_CHANNEL}. "
+                            f"Waiting up to {r.expires_in}s for approval..."
+                        ),
+                    )
+
+                    obo_expires_at = time.time() + obo_token.expires_in
+                    print("OBO token obtained successfully. Retrying your request...\n")
+
+                    client = MultiServerMCPClient(build_mcp_config(obo_token.access_token))
+                    tools = await client.get_tools()
+                    agent = create_agent(llm, tools)
+
+                    response = await agent.ainvoke(
+                        {"messages": [{"role": "user", "content": user_input}]}
+                    )
+                except Exception as e:
+                    error_msg = str(e)
+                    if "access_denied" in error_msg:
+                        print("The user denied the approval request.")
+                    elif "expired_token" in error_msg or "timed out" in error_msg:
+                        print("The approval request expired. The user did not respond in time.")
+                    elif "Client secret is required" in error_msg:
+                        print(
+                            "CLIENT_SECRET is not set. CIBA requires a confidential client.\n"
+                            "Set CLIENT_SECRET in your .env file. See: "
+                            "https://wso2.com/asgardeo/docs/guides/authentication/configure-ciba-grant/"
+                        )
+                    else:
+                        print(f"CIBA step-up failed: {e}")
+                    continue
+
+            print("Agent Response:", response["messages"][-1].content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/agent-identity/python/ciba-on-behalf-of-flow/langchain/requirements.txt
+++ b/agent-identity/python/ciba-on-behalf-of-flow/langchain/requirements.txt
@@ -1,0 +1,8 @@
+asgardeo>=0.2.0
+asgardeo_ai>=0.2.0
+
+langchain==1.2.1
+langchain-google-genai==3.2.0
+langchain-mcp-adapters==0.1.14
+
+python-dotenv~=1.0.0

--- a/mcp-auth/python-tasks/.env.example
+++ b/mcp-auth/python-tasks/.env.example
@@ -1,0 +1,9 @@
+# ---------------------------------------
+# Asgardeo JWT Validation Configuration
+# ---------------------------------------
+AUTH_ISSUER=https://api.asgardeo.io/t/<your-tenant>/oauth2/token
+CLIENT_ID=<your-client-id>
+JWKS_URL=https://api.asgardeo.io/t/<your-tenant>/oauth2/jwks
+
+# Server port (default: 8100, coexists with the calculator server on 8000)
+MCP_SERVER_PORT=8100

--- a/mcp-auth/python-tasks/README.md
+++ b/mcp-auth/python-tasks/README.md
@@ -1,0 +1,79 @@
+# MCP Auth Python Tasks Server - Asgardeo Integration
+
+A secured MCP server that exposes task-management tools with **per-tool scope enforcement**, designed to demonstrate the CIBA-based OBO step-up flow. Runs on port **8100** so it coexists with the existing calculator server on port 8000.
+
+## Prerequisites
+
+- Python 3.12 or higher
+- Asgardeo account and application setup
+- pip (Python package installer)
+
+## Project Structure
+
+```
+├── main.py              # FastMCP server with task tools and per-tool scope checks
+├── jwt_validator.py     # JWT validation module
+├── .env                 # Environment variables configuration
+├── README.md            # This file
+└── requirements.txt     # Python dependencies
+```
+
+## Installation
+
+1. **Create a virtual environment (recommended)**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+   ```
+
+2. **Install required dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Configure environment variables**
+
+   Copy `.env.example` to `.env` and fill in your Asgardeo configuration:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   | Variable | Description |
+   |---|---|
+   | `AUTH_ISSUER` | Asgardeo token issuer URL |
+   | `CLIENT_ID` | OAuth2 client ID from Asgardeo |
+   | `JWKS_URL` | Asgardeo JWKS endpoint URL |
+   | `MCP_SERVER_PORT` | Server port (default: `8100`) |
+
+## Asgardeo Configuration
+
+### API Resource & Scopes
+
+Register an API resource in Asgardeo with the following scopes:
+
+| Scope | Description |
+|---|---|
+| `tasks:templates_read` | Read task templates (non-user-specific) |
+| `tasks:read` | Read user's personal tasks |
+| `tasks:write` | Create tasks for the user |
+
+Authorize your MCP Client Application for these scopes.
+
+## Running the Server
+
+```bash
+python main.py
+```
+
+The server starts on `http://localhost:8100/mcp` using the `streamable-http` transport.
+
+## Available Tools
+
+| Tool | Required Scope | Description |
+|---|---|---|
+| `list_task_templates` | `tasks:templates_read` | Returns a static list of suggested task templates. No user data. |
+| `list_my_tasks` | `tasks:read` | Returns the caller's personal tasks (keyed by `sub` claim). |
+| `create_my_task` | `tasks:write` | Creates a task for the caller. |
+
+> **Note:** `list_my_tasks` and `create_my_task` require an OBO token with the user's `sub` claim. Task storage is in-memory and resets on server restart.

--- a/mcp-auth/python-tasks/jwt_validator.py
+++ b/mcp-auth/python-tasks/jwt_validator.py
@@ -1,0 +1,163 @@
+"""
+ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+
+  This software is the property of WSO2 LLC. and its suppliers, if any.
+  Dissemination of any information or reproduction of any material contained
+  herein is strictly forbidden, unless permitted by WSO2 in accordance with
+  the WSO2 Commercial License available at http://wso2.com/licenses.
+  For specific language governing the permissions and limitations under
+  this license, please see the license as well as any agreement you’ve
+  entered into with WSO2 governing the purchase of this software and any
+
+
+JWT Token Validation Module
+
+This module handles JWT token validation using JWKS (JSON Web Key Set).
+It provides a clean interface for validating JWT tokens with proper error handling.
+
+### JWT Validation Settings
+
+The JWTTokenVerifier supports the following features:
+- **Algorithm**: RS256 (configurable in JWTValidator)
+- **Expiration**: Verified automatically
+- **Audience**: Verified against CLIENT_ID
+- **Issuer**: Verified against AUTH_ISSUER
+- **Scopes**: Extracted and included in AccessToken
+"""
+
+import jwt
+from jwt.algorithms import RSAAlgorithm
+import httpx
+from typing import Dict, Any, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class JWTValidator:
+    """
+    A class to handle JWT token validation using JWKS.
+    Fetches and caches JWKS keys for performance.
+    """
+
+    def __init__(self, jwks_url: str, issuer: str, audience: str, ssl_verify: bool = True):
+        """
+        Initialize the JWT validator.
+        
+        Args:
+            jwks_url: The URL to fetch JWKS from
+            issuer: Expected token issuer
+            audience: Expected token audience
+            ssl_verify: Whether to verify SSL certificates (False for dev/testing)
+        """
+        self.jwks_url = jwks_url
+        self.issuer = issuer
+        self.audience = audience
+        self.ssl_verify = ssl_verify
+        self._jwks_cache: Optional[Dict[str, Any]] = None
+
+    async def _fetch_jwks(self) -> Dict[str, Any]:
+        """Fetch JWKS from the authorization server."""
+        try:
+            async with httpx.AsyncClient(verify=self.ssl_verify) as client:
+                response = await client.get(self.jwks_url)
+                response.raise_for_status()
+                return response.json()
+        except Exception as e:
+            logger.error(f"Failed to fetch JWKS from {self.jwks_url}: {e}")
+            raise
+
+    async def _get_jwks(self) -> Dict[str, Any]:
+        """Get JWKS, using cache if available."""
+        if self._jwks_cache is None:
+            self._jwks_cache = await self._fetch_jwks()
+        return self._jwks_cache
+
+    def _get_signing_key(self, token_header: Dict[str, Any], jwks: Dict[str, Any]) -> str:
+        """Extract the signing key from JWKS based on token header."""
+        kid = token_header.get('kid')
+        if not kid:
+            raise ValueError("Token header missing 'kid' field")
+
+        for key in jwks.get('keys', []):
+            if key.get('kid') == kid:
+                # Convert JWK to PEM format for PyJWT
+                return RSAAlgorithm.from_jwk(key)
+
+        raise ValueError(f"Unable to find matching key for kid: {kid}")
+
+    async def validate_token(self, token: str) -> Dict[str, Any]:
+        """
+        Validate a JWT token and return the decoded payload.
+
+        Args:
+            token: The JWT token to validate
+            
+        Returns:
+            Dict containing the decoded token payload with additional metadata
+
+        Raises:
+            ValueError: If token validation fails
+        """
+        try:
+            # Decode header without verification to get the key ID
+            unverified_header = jwt.get_unverified_header(token)
+
+            # Get JWKS
+            jwks = await self._get_jwks()
+
+            # Get the signing key
+            signing_key = self._get_signing_key(unverified_header, jwks)
+
+            # Decode and verify the token
+            payload = jwt.decode(
+                token,
+                signing_key,
+                algorithms=['RS256'],
+                issuer=self.issuer,
+                audience=self.audience,
+                options={
+                    "verify_signature": True,
+                    "verify_exp": True,
+                    "verify_iat": True,
+                    "verify_iss": True,
+                    "verify_aud": True
+                }
+            )
+
+            # Add metadata to the payload
+            payload['_validated_by'] = 'JWTValidator'
+            payload['_issuer'] = self.issuer
+            payload['_audience'] = self.audience
+
+            return payload
+
+        except jwt.ExpiredSignatureError:
+            raise ValueError("Token has expired")
+        except jwt.InvalidAudienceError:
+            raise ValueError("Invalid audience")
+        except jwt.InvalidIssuerError:
+            raise ValueError("Invalid issuer")
+        except jwt.InvalidSignatureError:
+            raise ValueError("Invalid token signature")
+        except jwt.DecodeError:
+            raise ValueError("Invalid token format")
+        except Exception as e:
+            logger.error(f"Token validation error: {e}")
+            raise ValueError(f"Token validation failed: {e}")
+
+
+def create_jwt_validator(jwks_url: str, issuer: str, audience: str, ssl_verify: bool = True) -> JWTValidator:
+    """
+    Factory function to create a JWT validator instance.
+    
+    Args:
+        jwks_url: The URL to fetch JWKS from
+        issuer: Expected token issuer
+        audience: Expected token audience
+        ssl_verify: Whether to verify SSL certificates
+        
+    Returns:
+        JWTValidator: Configured validator instance
+    """
+    return JWTValidator(jwks_url, issuer, audience, ssl_verify)

--- a/mcp-auth/python-tasks/main.py
+++ b/mcp-auth/python-tasks/main.py
@@ -1,0 +1,167 @@
+"""
+ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+
+  This software is the property of WSO2 LLC. and its suppliers, if any.
+  Dissemination of any information or reproduction of any material contained
+  herein is strictly forbidden, unless permitted by WSO2 in accordance with
+  the WSO2 Commercial License available at http://wso2.com/licenses.
+  For specific language governing the permissions and limitations under
+  this license, please see the license as well as any agreement you've
+  entered into with WSO2 governing the purchase of this software and any
+"""
+
+import os
+from datetime import datetime, timezone
+from dotenv import load_dotenv
+from pydantic import AnyHttpUrl
+
+load_dotenv()
+
+import jwt as pyjwt
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.fastmcp import FastMCP
+from jwt_validator import JWTValidator
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+TASK_TEMPLATES = [
+    {"id": "1", "title": "Weekly Report", "description": "Prepare and submit the weekly status report"},
+    {"id": "2", "title": "Code Review", "description": "Review pending pull requests and provide feedback"},
+    {"id": "3", "title": "Team Standup Notes", "description": "Document key points from the daily standup"},
+    {"id": "4", "title": "Bug Triage", "description": "Triage and prioritize incoming bug reports"},
+    {"id": "5", "title": "Sprint Retrospective", "description": "Prepare notes for the sprint retrospective meeting"},
+]
+
+
+# Sub extraction approach: Option (A) from spec §5.5.
+# The token has already been validated by JWTTokenVerifier upstream.
+# We re-decode with verify_signature=False to extract the `sub` claim.
+def get_user_id(token: AccessToken) -> str:
+    """Extract the user's subject identifier from a validated access token."""
+    payload = pyjwt.decode(token.token, options={"verify_signature": False})
+    sub = payload.get("sub")
+    if not sub:
+        raise PermissionError("Token does not contain a 'sub' claim. An OBO token is required.")
+    return sub
+
+
+def require_scopes(*needed: str) -> AccessToken:
+    """Enforce per-tool scopes. Returns the access token if all scopes are present."""
+    token = get_access_token()
+    if token is None:
+        raise PermissionError("No access token in request context.")
+    have = set(token.scopes or [])
+    missing = [s for s in needed if s not in have]
+    if missing:
+        raise PermissionError(
+            f"insufficient_scope: missing {missing}. "
+            "Step up via CIBA with these scopes."
+        )
+    return token
+
+
+# In-memory task store keyed by user id (sub claim)
+_task_store: dict[str, list[dict]] = {}
+
+
+class JWTTokenVerifier(TokenVerifier):
+    """JWT token verifier using Asgardeo JWKS."""
+
+    def __init__(self, jwks_url: str, issuer: str, client_id: str):
+        self.jwt_validator = JWTValidator(
+            jwks_url=jwks_url,
+            issuer=issuer,
+            audience=client_id,
+            ssl_verify=True
+        )
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        try:
+            payload = await self.jwt_validator.validate_token(token)
+
+            expires_at = payload.get("exp")
+            scopes = payload.get("scope", "").split() if payload.get("scope") else []
+            subject = payload.get("sub")
+            audience = payload.get("aud")
+            aut = payload.get("aut")
+            act = payload.get("act")
+
+            logger.info("[JWT VALID] " + ", ".join(
+                [f"sub={subject}", f"aut={aut}", f"scopes={scopes}"] +
+                ([f"act={act}"] if act else [])
+            ))
+
+            return AccessToken(
+                token=token,
+                client_id=audience if isinstance(audience, str) else self.jwt_validator.audience,
+                scopes=scopes,
+                expires_at=str(expires_at) if expires_at else None
+            )
+        except ValueError as e:
+            logger.warning(f"Token validation failed: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error during token validation: {e}")
+            return None
+
+
+AUTH_ISSUER = os.getenv("AUTH_ISSUER")
+CLIENT_ID = os.getenv("CLIENT_ID")
+JWKS_URL = os.getenv("JWKS_URL")
+MCP_SERVER_PORT = int(os.getenv("MCP_SERVER_PORT", "8100"))
+
+if not all([AUTH_ISSUER, CLIENT_ID, JWKS_URL]):
+    raise ValueError("Missing required environment variables: AUTH_ISSUER, CLIENT_ID, or JWKS_URL")
+
+mcp = FastMCP(
+    "Tasks Tool",
+    port=MCP_SERVER_PORT,
+    token_verifier=JWTTokenVerifier(JWKS_URL, AUTH_ISSUER, CLIENT_ID),
+    auth=AuthSettings(
+        issuer_url=AnyHttpUrl(AUTH_ISSUER),
+        resource_server_url=AnyHttpUrl(f"http://localhost:{MCP_SERVER_PORT}"),
+    ),
+)
+
+
+@mcp.tool()
+async def list_task_templates() -> list[dict]:
+    """List available task templates. Returns a static list of suggested task templates."""
+    require_scopes("tasks:templates_read")
+    return TASK_TEMPLATES
+
+
+@mcp.tool()
+async def list_my_tasks() -> list[dict]:
+    """List the caller's personal tasks."""
+    token = require_scopes("tasks:read")
+    user_id = get_user_id(token)
+    return _task_store.get(user_id, [])
+
+
+@mcp.tool()
+async def create_my_task(title: str, due: str | None = None) -> dict:
+    """Create a new task for the caller."""
+    token = require_scopes("tasks:write")
+    user_id = get_user_id(token)
+
+    if user_id not in _task_store:
+        _task_store[user_id] = []
+
+    task = {
+        "id": str(len(_task_store[user_id]) + 1),
+        "title": title,
+        "due": due,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "status": "pending",
+    }
+    _task_store[user_id].append(task)
+    return task
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/mcp-auth/python-tasks/requirements.txt
+++ b/mcp-auth/python-tasks/requirements.txt
@@ -1,0 +1,6 @@
+mcpauth~=0.1.1
+mcp~=1.12.3
+PyJWT~=2.10.1
+httpx~=0.27.0
+pydantic~=2.11.7
+python-dotenv~=1.0.0


### PR DESCRIPTION
## Summary

- Introduces a new **CIBA On-Behalf-Of (OBO) flow** sample under `agent-identity/python/ciba-on-behalf-of-flow/` using LangChain
- The agent starts with its own credentials, detects `insufficient_scope` from the MCP server, and steps up to user-delegated access by triggering a CIBA approval via email — no browser redirect needed
- Adds a companion **Tasks MCP server** (`mcp-auth/python-tasks/`) with per-tool scope enforcement (`tasks:templates_read`, `tasks:read`, `tasks:write`) to demonstrate the step-up flow
- Updates root `README.md` and `agent-identity/python/README.md` with links to the new samples

## Test plan

- [ ] Start the Tasks MCP server (`mcp-auth/python-tasks/`) and verify it runs on `http://localhost:8100/mcp`
- [ ] Run the CIBA LangChain sample and verify the agent can list task templates with the agent token alone
- [ ] Request a user-scoped operation (e.g., "show my tasks") and verify the CIBA step-up triggers an email to the user
- [ ] Approve the CIBA request via email and verify the agent retries successfully with the OBO token
- [ ] Verify subsequent requests reuse the cached OBO token without re-triggering CIBA